### PR TITLE
use event-listener to replace futures-channel

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,21 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+group_imports = "StdExternalCrate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "async-notify"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Sherlock Holo <sherlockya@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 repository = "https://github.com/Sherlock-Holo/async-notify"
 description = "A general version async Notify, like `tokio` Notify but can work with any async runtime."
@@ -10,8 +10,10 @@ description = "A general version async Notify, like `tokio` Notify but can work 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures-util = "0.3"
-futures-channel = "0.3"
+event-listener = "4"
+futures-core = "0.3"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
-async-std = { version = "1.6", features = ["attributes"] }
+async-global-executor = { version = "2", default-features = false }
+futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # async-notify
-an async-std notify like tokio notify
+
+a runtime independent Notify


### PR DESCRIPTION
## remove

- `Notify` won't implement `Stream` anymore

## add

- add `NotifyStream`

## internal

- use `event-listener` to replace `futures-channel`